### PR TITLE
Add: Alert CRUD operations

### DIFF
--- a/src/alert/alert.controller.ts
+++ b/src/alert/alert.controller.ts
@@ -1,34 +1,97 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Put,
+} from '@nestjs/common';
 import { AlertService } from './alert.service';
 import { CreateAlertDto } from './dto/create-alert.dto';
-import { UpdateAlertDto } from './dto/update-alert.dto';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Alert } from './schemas/alert.schema';
 
+@ApiTags('Alerts')
 @Controller('alert')
 export class AlertController {
   constructor(private readonly alertService: AlertService) {}
 
-  @Post()
-  create(@Body() createAlertDto: CreateAlertDto) {
+  @Post('/create')
+  @ApiOperation({
+    summary: 'Crear una nueva alerta',
+    description: 'Este endpoint permite generar una nueva alerta',
+  })
+  @ApiBody({ type: CreateAlertDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Alerta creada correctamente',
+    type: Alert,
+  })
+  async create(@Body() createAlertDto: CreateAlertDto): Promise<Alert> {
     return this.alertService.create(createAlertDto);
   }
 
-  @Get()
-  findAll() {
+  @Get('/list')
+  @ApiOperation({
+    summary: 'Obtener todas las alertas',
+    description: 'Este endpoint devuelve todas las alertas activas',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Listado de alertas',
+    type: [Alert],
+  })
+  findAll(): Promise<Alert[]> {
     return this.alertService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.alertService.findOne(+id);
+  @Get('/list/:alertId')
+  @ApiOperation({
+    summary: 'Obtener una alerta por ID',
+    description: 'Este endpoint devuelve una alerta específica',
+  })
+  @ApiParam({
+    name: 'alertId',
+    description: 'ID de la alerta a encontrar',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Alerta encontrada',
+    type: Alert,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Alerta no encontrada',
+  })
+  findOne(@Param('alertId') alertId: string): Promise<Alert> {
+    return this.alertService.findOne(alertId);
   }
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateAlertDto: UpdateAlertDto) {
-    return this.alertService.update(+id, updateAlertDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.alertService.remove(+id);
+  @Put('/delete/:alertId')
+  @ApiOperation({
+    summary: 'Eliminar una alerta',
+    description: 'Este endpoint elimina lógicamente una alerta específica',
+  })
+  @ApiParam({
+    name: 'alertId',
+    description: 'ID de la alerta a eliminar',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Alerta eliminada correctamente',
+    type: String,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Alerta no encontrada',
+  })
+  remove(@Param('alertId') alertId: string) {
+    return this.alertService.remove(alertId);
   }
 }

--- a/src/alert/dto/create-alert.dto.ts
+++ b/src/alert/dto/create-alert.dto.ts
@@ -1,1 +1,42 @@
-export class CreateAlertDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { EmployeeEmbeddedDto } from './employee-embedded.dto';
+import { Type } from 'class-transformer';
+
+export class CreateAlertDto {
+  @ApiProperty({
+    description: 'Mensaje de la alerta',
+    example: 'Aviso de combustible tipo SUPER bajo',
+  })
+  @IsString()
+  message: string;
+
+  @ApiProperty({
+    description: 'Módulo de destino',
+    example: 'Administración',
+  })
+  @IsString()
+  destination: string;
+
+  @ApiProperty({
+    type: EmployeeEmbeddedDto,
+    description: 'Datos de empleado que genera la alerta',
+    example: {
+      employeeId: 'EMP123',
+      employeeName: 'María Rojas',
+    },
+  })
+  @ValidateNested()
+  @Type(() => EmployeeEmbeddedDto)
+  createdBy: EmployeeEmbeddedDto;
+
+  @ApiProperty({ description: 'Estado de la alerta', example: true })
+  @IsBoolean()
+  @IsOptional()
+  status?: boolean = true;
+}

--- a/src/alert/dto/employee-embedded.dto.ts
+++ b/src/alert/dto/employee-embedded.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class EmployeeEmbeddedDto {
+  @ApiProperty({
+    description: 'ID del empleado',
+    example: 'EMP123',
+  })
+  @IsString()
+  employeeId: string;
+
+  @ApiProperty({
+    description: 'Nombre del empleado',
+    example: 'María Rojas',
+  })
+  @IsString()
+  employeeName: string;
+}


### PR DESCRIPTION
Implemented the following operations in <code>Alert</code> controller and service:
- Create new alert
- Find all alerts
- Find one alert by ID
- Soft delete an alert

> [!NOTE]
The <code>src/alert/dto/employee-embedded.dto.ts</code> file can be deleted once the PR #12 gets merged to re-use code. Also on the test I could notice that the id that mongo generates by default, can't get automatically assigned to **alertId**. It should be discussed if we are gonna use this field or just the default generated by mongo.